### PR TITLE
Note minimum required Node version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
   ],
   "author": "Phil Booth <pmbooth@gmail.com> (https://philbooth.me/)",
   "main": "index.js",
+  "engines": {
+    "node": ">= 6.0.0"
+  },
   "scripts": {
     "lint": "eslint .",
     "test": "mocha --es_staging --ui tdd test.js",


### PR DESCRIPTION
Per your note in the [`bfj` README.md](https://github.com/philbooth/bfj/blob/afe79334a7bcc227c45220de6f461c480ddb4fdd/README.md#what-versions-of-nodejs-does-it-support):

> ## What versions of Node.js does it support?
> 
> As of [version `3.0.0`](HISTORY.md#300), only Node.js versions 6 or greater are supported because of the dependency on [Hoopy](https://github.com/philbooth/hoopy). Previous versions supported node 4 and later.